### PR TITLE
Splitting sensors in VAT and ex VAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ Stromligning for Home Assistant integrates Day Ahead spotprices for electricity,
 
 The integration automatically recognises tariff settings from the Home Assistant home location coordinates and allows you to select your electricity vendor.
 
-## Known limitations/bugs
-* Additional templates are currently not working, even though it's possible to insert, it is __NOT__ taken into account in the final price
-
 ## Table of Content
 
 [**Installation**](#installation)

--- a/custom_components/stromligning/api.py
+++ b/custom_components/stromligning/api.py
@@ -29,7 +29,6 @@ class StromligningAPI:
 
         self.hass = hass
 
-        self.include_vat: bool = entry.options.get(CONF_USE_VAT)
         self._data = Stromligning()
 
         self.prices_today: list = []
@@ -114,25 +113,17 @@ class StromligningAPI:
             self.prices_tomorrow = []
             self.tomorrow_available = False
 
-    def get_current(self) -> str:
+    def get_current(self, vat: bool = True) -> str:
         """Get the current price"""
         for price in self.prices_today:
             if price["date"].hour == dt_utils.now().hour:
                 LOGGER.debug(
                     "Returning '%s' as current price",
-                    (
-                        price["price"]["total"]
-                        if self.include_vat
-                        else price["price"]["value"]
-                    ),
+                    (price["price"]["total"] if vat else price["price"]["value"]),
                 )
-                return (
-                    price["price"]["total"]
-                    if self.include_vat
-                    else price["price"]["value"]
-                )
+                return price["price"]["total"] if vat else price["price"]["value"]
 
-    def get_spot(self) -> str:
+    def get_spot(self, vat: bool = True) -> str:
         """Get spotprice"""
         for price in self.prices_today:
             if price["date"].hour == dt_utils.now().hour:
@@ -140,17 +131,17 @@ class StromligningAPI:
                     "Returning '%s' as current spotprice",
                     (
                         price["details"]["electricity"]["total"]
-                        if self.include_vat
+                        if vat
                         else price["details"]["electricity"]["value"]
                     ),
                 )
                 return (
                     price["details"]["electricity"]["total"]
-                    if self.include_vat
+                    if vat
                     else price["details"]["electricity"]["value"]
                 )
 
-    def get_electricitytax(self) -> str:
+    def get_electricitytax(self, vat: bool = True) -> str:
         """Get electricity tax"""
         for price in self.prices_today:
             if price["date"].hour == dt_utils.now().hour:
@@ -158,29 +149,29 @@ class StromligningAPI:
                     "Returning '%s' as current electricity tax",
                     (
                         price["details"]["electricityTax"]["total"]
-                        if self.include_vat
+                        if vat
                         else price["details"]["electricityTax"]["value"]
                     ),
                 )
                 return (
                     price["details"]["electricityTax"]["total"]
-                    if self.include_vat
+                    if vat
                     else price["details"]["electricityTax"]["value"]
                 )
 
-    def mean(self, data: list) -> float:
+    def mean(self, data: list, vat: bool = True) -> float:
         """Calculate mean value of list."""
         val = 0
         num = 0
 
         for i in data:
-            val += i["price"]["total"] if self.include_vat else i["price"]["value"]
+            val += i["price"]["total"] if vat else i["price"]["value"]
             num += 1
 
         return val / num
 
     def get_specific_today(
-        self, type: str, full_day: bool = False, date: bool = False
+        self, type: str, full_day: bool = False, date: bool = False, vat: bool = True
     ) -> str | datetime:
         """Get today specific price and time."""
         if not full_day:
@@ -200,9 +191,7 @@ class StromligningAPI:
 
         ret = {
             "date": res["date"].strftime("%H:%M:%S"),
-            "price": (
-                res["price"]["total"] if self.include_vat else res["price"]["value"]
-            ),
+            "price": (res["price"]["total"] if vat else res["price"]["value"]),
         }
 
         return ret["date"] if date else ret["price"]

--- a/custom_components/stromligning/config_flow.py
+++ b/custom_components/stromligning/config_flow.py
@@ -67,14 +67,9 @@ class StromligningOptionsFlow(config_entries.OptionsFlow):
 
         scheme = vol.Schema(
             {
-                vol.Required(
-                    CONF_USE_VAT,
-                    default=self.config_entry.options[CONF_USE_VAT],
-                ): bool,
                 vol.Required(CONF_COMPANY, default=selected_company): vol.In(
                     company_list
                 ),
-                vol.Optional(CONF_TEMPLATE): str,
             }
         )
 
@@ -133,9 +128,7 @@ class StromligningConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         scheme = vol.Schema(
             {
                 vol.Required(CONF_NAME, default=CONF_DEFAULT_NAME): str,
-                vol.Required(CONF_USE_VAT, default=True): bool,
                 vol.Required(CONF_COMPANY): vol.In(company_list),
-                vol.Optional(CONF_TEMPLATE): str,
             }
         )
 

--- a/custom_components/stromligning/sensor.py
+++ b/custom_components/stromligning/sensor.py
@@ -30,64 +30,136 @@ LOGGER = logging.getLogger(__name__)
 
 SENSORS = [
     StromligningSensorEntityDescription(
-        key="current_price",
+        key="current_price_vat",
         entity_category=None,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
         icon="mdi:flash",
-        value_fn=lambda stromligning: stromligning.get_current(),
+        value_fn=lambda stromligning: stromligning.get_current(True),
         suggested_display_precision=2,
-        translation_key="current_price",
+        entity_registry_enabled_default=True,
+        translation_key="current_price_vat",
     ),
     StromligningSensorEntityDescription(
-        key="spotprice",
+        key="current_price_ex_vat",
+        entity_category=None,
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        icon="mdi:flash",
+        value_fn=lambda stromligning: stromligning.get_current(False),
+        suggested_display_precision=2,
+        entity_registry_enabled_default=False,
+        translation_key="current_price_ex_vat",
+    ),
+    StromligningSensorEntityDescription(
+        key="spotprice_vat",
         entity_category=None,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
         icon="mdi:transmission-tower-import",
-        value_fn=lambda stromligning: stromligning.get_spot(),
+        value_fn=lambda stromligning: stromligning.get_spot(True),
         suggested_display_precision=2,
-        translation_key="spotprice",
+        entity_registry_enabled_default=True,
+        translation_key="spotprice_vat",
     ),
     StromligningSensorEntityDescription(
-        key="electricity_tax",
+        key="spotprice_ex_vat",
+        entity_category=None,
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        icon="mdi:transmission-tower-import",
+        value_fn=lambda stromligning: stromligning.get_spot(False),
+        suggested_display_precision=2,
+        entity_registry_enabled_default=False,
+        translation_key="spotprice_ex_vat",
+    ),
+    StromligningSensorEntityDescription(
+        key="electricity_tax_vat",
         entity_category=None,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
         icon="mdi:currency-eur",
-        value_fn=lambda stromligning: stromligning.get_electricitytax(),
+        value_fn=lambda stromligning: stromligning.get_electricitytax(True),
         suggested_display_precision=2,
-        translation_key="electricity_tax",
+        entity_registry_enabled_default=True,
+        translation_key="electricity_tax_vat",
     ),
     StromligningSensorEntityDescription(
-        key="today_min",
+        key="electricity_tax_ex_vat",
+        entity_category=None,
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        icon="mdi:currency-eur",
+        value_fn=lambda stromligning: stromligning.get_electricitytax(False),
+        suggested_display_precision=2,
+        entity_registry_enabled_default=False,
+        translation_key="electricity_tax_ex_vat",
+    ),
+    StromligningSensorEntityDescription(
+        key="today_min_vat",
         entity_category=None,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
         icon="mdi:flash",
-        value_fn=lambda stromligning: stromligning.get_specific_today("min"),
+        value_fn=lambda stromligning: stromligning.get_specific_today("min", True),
         suggested_display_precision=2,
-        translation_key="today_min",
+        entity_registry_enabled_default=True,
+        translation_key="today_min_vat",
     ),
     StromligningSensorEntityDescription(
-        key="today_max",
+        key="today_min_ex_vat",
         entity_category=None,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
         icon="mdi:flash",
-        value_fn=lambda stromligning: stromligning.get_specific_today("max"),
+        value_fn=lambda stromligning: stromligning.get_specific_today("min", False),
         suggested_display_precision=2,
-        translation_key="today_max",
+        entity_registry_enabled_default=False,
+        translation_key="today_min_ex_vat",
     ),
     StromligningSensorEntityDescription(
-        key="today_mean",
+        key="today_max_vat",
         entity_category=None,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
         icon="mdi:flash",
-        value_fn=lambda stromligning: stromligning.get_specific_today("mean"),
+        value_fn=lambda stromligning: stromligning.get_specific_today("max", True),
         suggested_display_precision=2,
-        translation_key="today_mean",
+        entity_registry_enabled_default=True,
+        translation_key="today_max_vat",
+    ),
+    StromligningSensorEntityDescription(
+        key="today_max_ex_vat",
+        entity_category=None,
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        icon="mdi:flash",
+        value_fn=lambda stromligning: stromligning.get_specific_today("max", False),
+        suggested_display_precision=2,
+        entity_registry_enabled_default=False,
+        translation_key="today_max_ex_vat",
+    ),
+    StromligningSensorEntityDescription(
+        key="today_mean_vat",
+        entity_category=None,
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        icon="mdi:flash",
+        value_fn=lambda stromligning: stromligning.get_specific_today("mean", True),
+        suggested_display_precision=2,
+        entity_registry_enabled_default=True,
+        translation_key="today_mean_vat",
+    ),
+    StromligningSensorEntityDescription(
+        key="today_mean_ex_vat",
+        entity_category=None,
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        icon="mdi:flash",
+        value_fn=lambda stromligning: stromligning.get_specific_today("mean", False),
+        suggested_display_precision=2,
+        entity_registry_enabled_default=False,
+        translation_key="today_mean_ex_vat",
     ),
 ]
 
@@ -163,7 +235,7 @@ class StromligningSensor(SensorEntity):
 
     async def handle_attributes(self) -> None:
         """Handle attributes."""
-        if self.entity_description.key == "current_price":
+        if self.entity_description.key == "current_price_vat":
             self._attr_extra_state_attributes = {}
             price_set: list = []
             for price in self.api.prices_today:
@@ -171,24 +243,43 @@ class StromligningSensor(SensorEntity):
                     {
                         "start": price["date"],
                         "end": price["date"] + timedelta(hours=1),
-                        "price": (
-                            price["price"]["total"]
-                            if self.api.include_vat
-                            else price["price"]["value"]
-                        ),
+                        "price": price["price"]["total"],
                     }
                 )
 
             self._attr_extra_state_attributes.update({"prices": price_set})
-        elif self.entity_description.key == "today_min":
+        if self.entity_description.key == "current_price_ex_vat":
+            self._attr_extra_state_attributes = {}
+            price_set: list = []
+            for price in self.api.prices_today:
+                price_set.append(
+                    {
+                        "start": price["date"],
+                        "end": price["date"] + timedelta(hours=1),
+                        "price": price["price"]["value"],
+                    }
+                )
+
+            self._attr_extra_state_attributes.update({"prices": price_set})
+        elif self.entity_description.key == "today_min_vat":
             self._attr_extra_state_attributes = {}
             self._attr_extra_state_attributes.update(
-                {"at": self.api.get_specific_today("min", date=True)}
+                {"at": self.api.get_specific_today("min", date=True, vat=True)}
             )
-        elif self.entity_description.key == "today_max":
+        elif self.entity_description.key == "today_min_ex_vat":
             self._attr_extra_state_attributes = {}
             self._attr_extra_state_attributes.update(
-                {"at": self.api.get_specific_today("max", date=True)}
+                {"at": self.api.get_specific_today("min", date=True, vat=False)}
+            )
+        elif self.entity_description.key == "today_max_vat":
+            self._attr_extra_state_attributes = {}
+            self._attr_extra_state_attributes.update(
+                {"at": self.api.get_specific_today("max", date=True, vat=True)}
+            )
+        elif self.entity_description.key == "today_max_ex_vat":
+            self._attr_extra_state_attributes = {}
+            self._attr_extra_state_attributes.update(
+                {"at": self.api.get_specific_today("max", date=True, vat=False)}
             )
 
     async def handle_update(self) -> None:

--- a/custom_components/stromligning/translations/da.json
+++ b/custom_components/stromligning/translations/da.json
@@ -10,9 +10,7 @@
             "user": {
                 "data": {
                     "name": "Navn til integrationen",
-                    "vat": "Vis priserne med moms",
-                    "company": "El leverandør",
-                    "extra_cost_template": "Skabelon til ekstra omkostninger"
+                    "company": "El leverandør"
                 }
             }
         }
@@ -28,52 +26,98 @@
             "init": {
                 "data": {
                     "name": "Navn til integrationen",
-                    "vat": "Vis priserne med moms",
-                    "company": "El leverandør",
-                    "extra_cost_template": "Skabelon til ekstra omkostninger"
+                    "company": "El leverandør"
                 }
             }
         }
     },
     "entity": {
         "sensor": {
-            "current_price": {
-                "name": "Aktuel",
+            "current_price_vat": {
+                "name": "Aktuel inkl. moms",
                 "state_attributes": {
                     "prices": {
                         "name": "Priser i dag"
                     }
                 }
             },
-            "spotprice": {
-                "name": "Spotpris"
+            "current_price_ex_vat": {
+                "name": "Aktuel ekskl. moms",
+                "state_attributes": {
+                    "prices": {
+                        "name": "Priser i dag"
+                    }
+                }
             },
-            "electricity_tax": {
-                "name": "Elafgift"
+            "spotprice_vat": {
+                "name": "Spotpris inkl. moms"
             },
-            "today_min": {
-                "name": "Minimum pris resten af dagen",
+            "spotprice_ex_vat": {
+                "name": "Spotpris ekskl. moms"
+            },
+            "electricity_tax_vat": {
+                "name": "Elafgift inkl. moms"
+            },
+            "electricity_tax_ex_vat": {
+                "name": "Elafgift ekskl. moms"
+            },
+            "today_min_vat": {
+                "name": "Minimum pris resten af dagen inkl. moms",
                 "state_attributes": {
                     "at": {
                         "name": "Tidspunkt"
                     }
                 }
             },
-            "today_max": {
-                "name": "Maximum pris resten af dagen",
+            "today_min_ex_vat": {
+                "name": "Minimum pris resten af dagen ekskl. moms",
                 "state_attributes": {
                     "at": {
                         "name": "Tidspunkt"
                     }
                 }
             },
-            "today_mean": {
-                "name": "Gennemsnits pris resten af dagen"
+            "today_max_vat": {
+                "name": "Maximum pris resten af dagen inkl. moms",
+                "state_attributes": {
+                    "at": {
+                        "name": "Tidspunkt"
+                    }
+                }
+            },
+            "today_max_ex_vat": {
+                "name": "Maximum pris resten af dagen ekskl. moms",
+                "state_attributes": {
+                    "at": {
+                        "name": "Tidspunkt"
+                    }
+                }
+            },
+            "today_mean_vat": {
+                "name": "Gennemsnits pris resten af dagen inkl. moms"
+            },
+            "today_mean_ex_vat": {
+                "name": "Gennemsnits pris resten af dagen ekskl. moms"
             }
         },
         "binary_sensor": {
-            "tomorrow_available": {
-                "name": "Priser for i morgen",
+            "tomorrow_available_vat": {
+                "name": "Priser for i morgen inkl. moms",
+                "state": {
+                    "on": "Klar",
+                    "off": "Endnu ikke klar"
+                },
+                "state_attributes": {
+                    "available_at": {
+                        "name": "Forventes klar"
+                    },
+                    "prices": {
+                        "name": "Priser for i morgen"
+                    }
+                }
+            },
+            "tomorrow_available_ex_vat": {
+                "name": "Priser for i morgen ekskl. moms",
                 "state": {
                     "on": "Klar",
                     "off": "Endnu ikke klar"

--- a/custom_components/stromligning/translations/en.json
+++ b/custom_components/stromligning/translations/en.json
@@ -10,9 +10,7 @@
             "user": {
                 "data": {
                     "name": "Name for this integration",
-                    "vat": "Show prices including VAT",
-                    "company": "Electricity provider",
-                    "extra_cost_template": "Template for additional costs"
+                    "company": "Electricity provider"
                 }
             }
         }
@@ -28,47 +26,83 @@
             "init": {
                 "data": {
                     "name": "Name for this integration",
-                    "vat": "Show prices including VAT",
-                    "company": "Electricity provider",
-                    "extra_cost_template": "Template for additional costs"
+                    "company": "Electricity provider"
                 }
             }
         }
     },
     "entity": {
         "sensor": {
-            "current_price": {
-                "name": "Current",
+            "current_price_vat": {
+                "name": "Current incl. VAT",
                 "state_attributes": {
                     "prices": {
                         "name": "Prices today"
                     }
                 }
             },
-            "spotprice": {
-                "name": "Spotprice"
+            "current_price_ex_vat": {
+                "name": "Current excl. VAT",
+                "state_attributes": {
+                    "prices": {
+                        "name": "Prices today"
+                    }
+                }
             },
-            "electricity_tax": {
-                "name": "Electricity tax"
+            "spotprice_vat": {
+                "name": "Spotprice incl. VAT"
             },
-            "today_min": {
-                "name": "Minimum price rest of the day",
+            "spotprice_ex_vat": {
+                "name": "Spotprice excl. VAT"
+            },
+            "electricity_tax_vat": {
+                "name": "Electricity tax incl. VAT"
+            },
+            "electricity_tax_ex_vat": {
+                "name": "Electricity tax excl. VAT"
+            },
+            "today_min_vat": {
+                "name": "Minimum price rest of the day incl. VAT",
                 "state_attributes": {
                     "at": {
                         "name": "At"
                     }
                 }
             },
-            "today_max": {
-                "name": "Maximum price rest of the day",
+            "today_min_ex_vat": {
+                "name": "Minimum price rest of the day excl. VAT",
                 "state_attributes": {
                     "at": {
                         "name": "At"
                     }
                 }
             },
-            "today_mean": {
-                "name": "Mean price rest of the day",
+            "today_max_vat": {
+                "name": "Maximum price rest of the day incl. VAT",
+                "state_attributes": {
+                    "at": {
+                        "name": "At"
+                    }
+                }
+            },
+            "today_max_ex_vat": {
+                "name": "Maximum price rest of the day excl. VAT",
+                "state_attributes": {
+                    "at": {
+                        "name": "At"
+                    }
+                }
+            },
+            "today_mean_vat": {
+                "name": "Mean price rest of the day incl. VAT",
+                "state_attributes": {
+                    "at": {
+                        "name": "At"
+                    }
+                }
+            },
+            "today_mean_ex_vat": {
+                "name": "Mean price rest of the day excl. VAT",
                 "state_attributes": {
                     "at": {
                         "name": "At"
@@ -77,8 +111,23 @@
             }
         },
         "binary_sensor": {
-            "tomorrow_available": {
-                "name": "Prices for tomorrow",
+            "tomorrow_available_vat": {
+                "name": "Prices for tomorrow incl. VAT",
+                "state": {
+                    "on": "Available",
+                    "off": "Not available yet"
+                },
+                "state_attributes": {
+                    "available_at": {
+                        "name": "Available at"
+                    },
+                    "prices": {
+                        "name": "Prices tomorrow"
+                    }
+                }
+            },
+            "tomorrow_available_ex_vat": {
+                "name": "Prices for tomorrow excl. VAT",
                 "state": {
                     "on": "Available",
                     "off": "Not available yet"


### PR DESCRIPTION
This is a breaking change as entity names changes and leaving old sensors unavailable

Entities excl. VAT is by default disabled and for the user to enable