### PR TITLE
Fixes inconsistency between `end` format at midnight

### DIFF
--- a/custom_components/stromligning/binary_sensor.py
+++ b/custom_components/stromligning/binary_sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from homeassistant.components import binary_sensor
 from homeassistant.components.binary_sensor import BinarySensorEntity
@@ -126,12 +126,13 @@ class StromligningBinarySensor(BinarySensorEntity):
                 {
                     "end": (
                         dt_utils.as_local(
-                            (dt_utils.now() + timedelta(days=1)).replace(
-                                hour=0, minute=0, second=0, microsecond=0
+                            datetime.fromisoformat(
+								(dt_utils.now() + timedelta(days=1)).replace(
+									hour=0, minute=0, second=0, microsecond=0
+								)
+                                .isoformat()
                             )
                         )
-                        .isoformat()
-                        .replace("+00:00", ".000Z")
                     )
                 }
             )
@@ -161,12 +162,13 @@ class StromligningBinarySensor(BinarySensorEntity):
                 {
                     "end": (
                         dt_utils.as_local(
-                            (dt_utils.now() + timedelta(days=1)).replace(
-                                hour=0, minute=0, second=0, microsecond=0
+                            datetime.fromisoformat(
+								(dt_utils.now() + timedelta(days=1)).replace(
+									hour=0, minute=0, second=0, microsecond=0
+								)
+                                .isoformat()
                             )
                         )
-                        .isoformat()
-                        .replace("+00:00", ".000Z")
                     )
                 }
             )

--- a/custom_components/stromligning/sensor.py
+++ b/custom_components/stromligning/sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components import sensor
@@ -502,12 +502,13 @@ class StromligningSensor(SensorEntity):
                 {
                     "end": (
                         dt_utils.as_local(
-                            (dt_utils.now() + timedelta(days=1)).replace(
-                                hour=0, minute=0, second=0, microsecond=0
+                            datetime.fromisoformat(
+								(dt_utils.now() + timedelta(days=1)).replace(
+									hour=0, minute=0, second=0, microsecond=0
+								)
+                                .isoformat()
                             )
                         )
-                        .isoformat()
-                        .replace("+00:00", ".000Z")
                     )
                 }
             )
@@ -534,12 +535,13 @@ class StromligningSensor(SensorEntity):
                 {
                     "end": (
                         dt_utils.as_local(
-                            (dt_utils.now() + timedelta(days=1)).replace(
-                                hour=0, minute=0, second=0, microsecond=0
+                            datetime.fromisoformat(
+								(dt_utils.now() + timedelta(days=1)).replace(
+									hour=0, minute=0, second=0, microsecond=0
+								)
+                                .isoformat()
                             )
                         )
-                        .isoformat()
-                        .replace("+00:00", ".000Z")
                     )
                 }
             )
@@ -566,12 +568,13 @@ class StromligningSensor(SensorEntity):
                 {
                     "end": (
                         dt_utils.as_local(
-                            (dt_utils.now() + timedelta(days=1)).replace(
-                                hour=0, minute=0, second=0, microsecond=0
+                            datetime.fromisoformat(
+								(dt_utils.now() + timedelta(days=1)).replace(
+									hour=0, minute=0, second=0, microsecond=0
+								)
+                                .isoformat()
                             )
                         )
-                        .isoformat()
-                        .replace("+00:00", ".000Z")
                     )
                 }
             )
@@ -598,12 +601,13 @@ class StromligningSensor(SensorEntity):
                 {
                     "end": (
                         dt_utils.as_local(
-                            (dt_utils.now() + timedelta(days=1)).replace(
-                                hour=0, minute=0, second=0, microsecond=0
+                            datetime.fromisoformat(
+								(dt_utils.now() + timedelta(days=1)).replace(
+									hour=0, minute=0, second=0, microsecond=0
+								)
+                                .isoformat()
                             )
                         )
-                        .isoformat()
-                        .replace("+00:00", ".000Z")
                     )
                 }
             )
@@ -677,12 +681,13 @@ class StromligningSensor(SensorEntity):
                 {
                     "end": (
                         dt_utils.as_local(
-                            (price["date"] + timedelta(days=1)).replace(
-                                hour=0, minute=0, second=0, microsecond=0
+                            datetime.fromisoformat(
+								(dt_utils.now() + timedelta(days=1)).replace(
+									hour=0, minute=0, second=0, microsecond=0
+								)
+                                .isoformat()
                             )
                         )
-                        .isoformat()
-                        .replace("+00:00", ".000Z")
                     )
                 }
             )


### PR DESCRIPTION
Fixes #171. Now it has proper timezone defined.
```
{'price': 2.174888, 'start': datetime.datetime(2025, 9, 13, 22, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Copenhagen')), 'end': datetime.datetime(2025, 9, 13, 23, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Copenhagen'))}
{'price': 2.055263, 'start': datetime.datetime(2025, 9, 13, 23, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Copenhagen')), 'end': datetime.datetime(2025, 9, 14, 0, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Copenhagen'))}
{'price': 1.847327, 'start': datetime.datetime(2025, 9, 14, 0, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Copenhagen')), 'end': datetime.datetime(2025, 9, 14, 1, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Copenhagen'))}
```