### PR TITLE
Remove whitespace in output from FindCheapestPeriod.jinja

### DIFF
--- a/custom_templates/FindCheapestPeriod.jinja
+++ b/custom_templates/FindCheapestPeriod.jinja
@@ -1,37 +1,37 @@
-{% macro FindCheapestPeriod(earliestDatetime, latestDatetime, durationTimedelta, findLastPeriodBoolean) %}
+{%- macro FindCheapestPeriod(earliestDatetime, latestDatetime, durationTimedelta, findLastPeriodBoolean) -%}
 
 {# Prepare input parameters #}
-{% set earliestDatetime = now() if earliestDatetime is not defined or earliestDatetime is not datetime else earliestDatetime %}
-{% set latestDatetime = now()+timedelta(days=7) if latestDatetime is not defined or latestDatetime is not datetime else latestDatetime %}
-{% set durationTimedelta = timedelta(hours=1) if durationTimedelta is not defined or durationTimedelta < timedelta(hours=1) else durationTimedelta %}
-{% set durationMinutes = durationTimedelta.total_seconds() // 60 | int %}
-{% set durationHours = "%.0f"|format((durationMinutes+30) // 60 | round | float) | int %}
+{%- set earliestDatetime = now() if earliestDatetime is not defined or earliestDatetime is not datetime else earliestDatetime -%}
+{%- set latestDatetime = now()+timedelta(days=7) if latestDatetime is not defined or latestDatetime is not datetime else latestDatetime -%}
+{%- set durationTimedelta = timedelta(hours=1) if durationTimedelta is not defined or durationTimedelta < timedelta(hours=1) else durationTimedelta -%}
+{%- set durationMinutes = durationTimedelta.total_seconds() // 60 | int -%}
+{%- set durationHours = "%.0f"|format((durationMinutes+30) // 60 | round | float) | int -%}
 
 {# Retrieve energy prices #}
-{% set energyPriceToday = "sensor.stromligning_current_price_vat" %}
-{% set energyPriceTomorrow = "binary_sensor.stromligning_tomorrow_available_vat" %}
-{% set today = state_attr(energyPriceToday, 'prices') %}
-{% set tomorrow = state_attr(energyPriceTomorrow, 'prices') %}
-{% set prices = (today if today else []) + (tomorrow if tomorrow else []) %}
+{%- set energyPriceToday = "sensor.stromligning_current_price_vat" -%}
+{%- set energyPriceTomorrow = "binary_sensor.stromligning_tomorrow_available_vat" -%}
+{%- set today = state_attr(energyPriceToday, 'prices') -%}
+{%- set tomorrow = state_attr(energyPriceTomorrow, 'prices') -%}
+{%- set prices = (today if today else []) + (tomorrow if tomorrow else []) -%}
 
 {# Calculate cheapest period #}
-{% set result = namespace(priceSum=999999, priceStartTime=None) %}
-{% set prices_len = (prices | length) - durationHours | int %}
-{% for n in range(prices_len) %}
-  {% set priceStartTime = prices[n].start %}
-  {% if earliestDatetime <= priceStartTime and priceStartTime <= latestDatetime %}
-    {% set priceSum = namespace(value=0) %}
-    {% for i in range(durationHours) %}
-      {% set priceSum.value = priceSum.value + prices[n+i].price %}
-    {% endfor %}
-    {% if priceSum.value<result.priceSum or (findLastPeriodBoolean and priceSum.value<=result.priceSum) %}
-      {% set result.priceSum = priceSum.value %}
-      {% set result.priceStartTime = priceStartTime %}
-    {% endif %}
-  {% endif %}
-{% endfor %}
+{%- set result = namespace(priceSum=999999, priceStartTime=None) -%}
+{%- set prices_len = (prices | length) - durationHours | int -%}
+{%- for n in range(prices_len) -%}
+  {%- set priceStartTime = prices[n].start -%}
+  {%- if earliestDatetime <= priceStartTime and priceStartTime <= latestDatetime -%}
+    {%- set priceSum = namespace(value=0) -%}
+    {%- for i in range(durationHours) -%}
+      {%- set priceSum.value = priceSum.value + prices[n+i].price -%}
+    {%- endfor -%}
+    {%- if priceSum.value<result.priceSum or (findLastPeriodBoolean and priceSum.value<=result.priceSum) -%}
+      {%- set result.priceSum = priceSum.value -%}
+      {%- set result.priceStartTime = priceStartTime -%}
+    {%- endif -%}
+  {%- endif -%}
+{%- endfor -%}
 
 {# Output result #}
 {{ result.priceStartTime + timedelta(seconds=durationHours*30*60-durationMinutes*30) }}
 
-{% endmacro %}
+{%- endmacro -%}


### PR DESCRIPTION
The Jinja template outputs a lot of whitespace before and after the actual string value we are interested in.  This makes it very difficult to parse the date string if you for instance would like to show cheapest period as "Wednesday 01:00 - 04:00" instead of the long UTC date string.

Ref: https://jinja.palletsprojects.com/en/stable/templates/#whitespace-control.