### PR TITLE
Add pytest coverage for price periods and rollover logic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+"""Shared pytest fixtures for the Stromligning integration."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+@pytest.fixture
+def mock_entry() -> SimpleNamespace:
+    """Return a lightweight config entry stand-in for unit tests."""
+    return SimpleNamespace(
+        entry_id="test-entry-id",
+        data={"name": "Strømligning Test"},
+        options={
+            "aggregation": "1h",
+            "company": "company-id",
+            "forecasts": False,
+        },
+    )
+
+
+@pytest.fixture
+def mock_hass() -> SimpleNamespace:
+    """Return a lightweight Home Assistant stand-in for unit tests."""
+    return SimpleNamespace(
+        data={},
+        config=SimpleNamespace(latitude=55.6761, longitude=12.5683),
+        config_entries=SimpleNamespace(
+            async_forward_entry_setups=AsyncMock(return_value=True),
+            async_forward_entry_unload=AsyncMock(return_value=True),
+        ),
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,148 @@
+"""Tests for Stromligning API data preparation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.stromligning.api import StromligningAPI
+
+
+def _build_api(mock_hass, mock_entry, prices: list[dict]) -> StromligningAPI:
+    """Create a partially initialized API object for focused unit tests."""
+    api = StromligningAPI.__new__(StromligningAPI)
+    api.hass = mock_hass
+    api._entry = mock_entry
+    api._data = SimpleNamespace(prices=prices)
+    api.prices_today = []
+    api.prices_tomorrow = []
+    api.prices_forecasts = []
+    api.forecast_data = False
+    api.tomorrow_available = False
+    api.listeners = []
+    api.last_update = None
+    return api
+
+
+@pytest.mark.asyncio
+async def test_prepare_data_splits_prices_into_today_tomorrow_and_forecasts(
+    monkeypatch, mock_hass, mock_entry
+) -> None:
+    """Prepared price lists should be bucketed by day boundaries."""
+    fixed_now = datetime(2026, 2, 24, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr(
+        "custom_components.stromligning.api.dt_utils.now",
+        lambda: fixed_now,
+    )
+    monkeypatch.setattr(
+        "custom_components.stromligning.api.dt_utils.as_local",
+        lambda value: value,
+    )
+    sent_signals: list[str] = []
+    monkeypatch.setattr(
+        "custom_components.stromligning.api.async_dispatcher_send",
+        lambda hass, signal: sent_signals.append(signal),
+    )
+
+    prices = [
+        {"date": "2026-02-24T00:00:00+00:00", "price": {"total": 1.0}},
+        {"date": "2026-02-24T23:00:00+00:00", "price": {"total": 1.1}},
+        {
+            "date": "2026-02-25T00:00:00+00:00",
+            "price": {"total": 1.2},
+            "forecast": True,
+        },
+        {
+            "date": "2026-02-25T23:00:00+00:00",
+            "price": {"total": 1.3},
+            "forecast": True,
+        },
+        {"date": "2026-02-26T00:00:00+00:00", "price": {"total": 1.4}},
+    ]
+    api = _build_api(mock_hass, mock_entry, prices)
+
+    await api.prepare_data()
+
+    assert [price["date"] for price in api.prices_today] == [
+        datetime(2026, 2, 24, 0, 0, tzinfo=UTC),
+        datetime(2026, 2, 24, 23, 0, tzinfo=UTC),
+    ]
+    assert [price["date"] for price in api.prices_tomorrow] == [
+        datetime(2026, 2, 25, 0, 0, tzinfo=UTC),
+        datetime(2026, 2, 25, 23, 0, tzinfo=UTC),
+    ]
+    assert [price["date"] for price in api.prices_forecasts] == [
+        datetime(2026, 2, 26, 0, 0, tzinfo=UTC)
+    ]
+    assert api.forecast_data is True
+    assert api.tomorrow_available is False
+    assert sent_signals
+
+
+@pytest.mark.asyncio
+async def test_prepare_data_marks_tomorrow_available_with_full_non_forecast_dataset(
+    monkeypatch, mock_hass, mock_entry
+) -> None:
+    """Tomorrow prices should stay populated when enough non-forecast entries exist."""
+    fixed_now = datetime(2026, 2, 24, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr(
+        "custom_components.stromligning.api.dt_utils.now",
+        lambda: fixed_now,
+    )
+    monkeypatch.setattr(
+        "custom_components.stromligning.api.dt_utils.as_local",
+        lambda value: value,
+    )
+    monkeypatch.setattr(
+        "custom_components.stromligning.api.async_dispatcher_send",
+        lambda hass, signal: None,
+    )
+
+    prices = [
+        {
+            "date": f"2026-02-25T{hour:02d}:00:00+00:00",
+            "price": {"total": 1.0 + hour},
+        }
+        for hour in range(24)
+    ]
+    api = _build_api(mock_hass, mock_entry, prices)
+
+    await api.prepare_data()
+
+    assert len(api.prices_tomorrow) == 24
+    assert api.forecast_data is False
+    assert api.tomorrow_available is True
+
+
+@pytest.mark.asyncio
+async def test_prepare_data_clears_incomplete_tomorrow_without_forecasts(
+    monkeypatch, mock_hass, mock_entry
+) -> None:
+    """Incomplete tomorrow data should be cleared when it is not forecast data."""
+    fixed_now = datetime(2026, 2, 24, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr(
+        "custom_components.stromligning.api.dt_utils.now",
+        lambda: fixed_now,
+    )
+    monkeypatch.setattr(
+        "custom_components.stromligning.api.dt_utils.as_local",
+        lambda value: value,
+    )
+    monkeypatch.setattr(
+        "custom_components.stromligning.api.async_dispatcher_send",
+        lambda hass, signal: None,
+    )
+
+    prices = [
+        {"date": "2026-02-25T00:00:00+00:00", "price": {"total": 1.0}},
+        {"date": "2026-02-25T01:00:00+00:00", "price": {"total": 1.1}},
+    ]
+    api = _build_api(mock_hass, mock_entry, prices)
+
+    await api.prepare_data()
+
+    assert api.prices_tomorrow == []
+    assert api.forecast_data is False
+    assert api.tomorrow_available is False

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,84 @@
+"""Tests for shared period-building helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from custom_components.stromligning.base import build_price_attributes
+
+
+def test_build_price_attributes_returns_empty_list_for_empty_input() -> None:
+    """An empty dataset should not leave behind a dangling partial period."""
+    assert build_price_attributes([], lambda price: price["price"]["total"], "1h") == {
+        "prices": []
+    }
+
+
+def test_build_price_attributes_uses_next_start_and_final_interval() -> None:
+    """The final period end should be derived from the dataset interval."""
+    prices = [
+        {
+            "date": datetime(2026, 2, 24, 21, 0, tzinfo=UTC),
+            "price": {"total": 1.1},
+        },
+        {
+            "date": datetime(2026, 2, 24, 22, 0, tzinfo=UTC),
+            "price": {"total": 1.2},
+        },
+        {
+            "date": datetime(2026, 2, 24, 23, 0, tzinfo=UTC),
+            "price": {"total": 1.3},
+        },
+    ]
+
+    result = build_price_attributes(
+        prices,
+        lambda price: price["price"]["total"],
+        "1h",
+    )
+
+    assert result == {
+        "prices": [
+            {
+                "price": 1.1,
+                "start": datetime(2026, 2, 24, 21, 0, tzinfo=UTC),
+                "end": datetime(2026, 2, 24, 22, 0, tzinfo=UTC),
+            },
+            {
+                "price": 1.2,
+                "start": datetime(2026, 2, 24, 22, 0, tzinfo=UTC),
+                "end": datetime(2026, 2, 24, 23, 0, tzinfo=UTC),
+            },
+            {
+                "price": 1.3,
+                "start": datetime(2026, 2, 24, 23, 0, tzinfo=UTC),
+                "end": datetime(2026, 2, 25, 0, 0, tzinfo=UTC),
+            },
+        ]
+    }
+
+
+def test_build_price_attributes_uses_aggregation_fallback_for_single_value() -> None:
+    """A single 15 minute datapoint should still yield the right period end."""
+    prices = [
+        {
+            "date": datetime(2026, 2, 24, 23, 45, tzinfo=UTC),
+            "price": {"total": 1.3},
+        }
+    ]
+
+    result = build_price_attributes(
+        prices,
+        lambda price: price["price"]["total"],
+        "15m",
+    )
+
+    assert result == {
+        "prices": [
+            {
+                "price": 1.3,
+                "start": datetime(2026, 2, 24, 23, 45, tzinfo=UTC),
+                "end": datetime(2026, 2, 25, 0, 0, tzinfo=UTC),
+            }
+        ]
+    }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,99 @@
+"""Tests for integration setup scheduling and rollover behavior."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.stromligning import async_setup_entry
+from custom_components.stromligning.const import DOMAIN
+
+
+class FakeAPI:
+    """Simple API stub used to capture setup side effects."""
+
+    def __init__(self, hass, entry, rand_min: int, rand_sec: int) -> None:
+        """Initialize the fake API."""
+        self.hass = hass
+        self.entry = entry
+        self.rand_min = rand_min
+        self.rand_sec = rand_sec
+        self.prices_today = []
+        self.prices_tomorrow = [{"date": "tomorrow-price"}]
+        self.prices_forecasts = []
+        self.forecast_data = False
+        self.tomorrow_available = True
+        self.listeners = []
+        self.set_location_calls = 0
+        self.update_prices_calls = 0
+        self.prepare_data_calls = 0
+
+    async def set_location(self) -> None:
+        """Track initial setup."""
+        self.set_location_calls += 1
+
+    async def update_prices(self) -> None:
+        """Track fetch attempts."""
+        self.update_prices_calls += 1
+
+    async def prepare_data(self) -> None:
+        """Track data preparation calls."""
+        self.prepare_data_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_rolls_tomorrow_into_today_at_midnight(
+    monkeypatch, mock_hass, mock_entry
+) -> None:
+    """The scheduled midnight callback should move tomorrow data into today."""
+    callbacks = []
+    dispatches: list[str] = []
+
+    def track_time_change(hass, action, **kwargs):
+        callbacks.append((kwargs, action))
+        return lambda: None
+
+    async def get_integration(hass, domain):
+        return SimpleNamespace(version="test")
+
+    monkeypatch.setattr(
+        "custom_components.stromligning.async_get_integration",
+        get_integration,
+    )
+    monkeypatch.setattr("custom_components.stromligning.randint", lambda start, end: 5)
+    monkeypatch.setattr("custom_components.stromligning.StromligningAPI", FakeAPI)
+    monkeypatch.setattr(
+        "custom_components.stromligning.async_track_time_change",
+        track_time_change,
+    )
+    monkeypatch.setattr(
+        "custom_components.stromligning.async_track_utc_time_change",
+        track_time_change,
+    )
+    monkeypatch.setattr(
+        "custom_components.stromligning.async_dispatcher_send",
+        lambda hass, signal: dispatches.append(signal),
+    )
+
+    result = await async_setup_entry(mock_hass, mock_entry)
+
+    assert result is True
+    api = mock_hass.data[DOMAIN][mock_entry.entry_id]
+    assert api.set_location_calls == 1
+    assert api.update_prices_calls == 1
+    assert api.prepare_data_calls == 1
+
+    midnight_callback = next(
+        action
+        for kwargs, action in callbacks
+        if kwargs == {"hour": 0, "minute": 0, "second": 1}
+    )
+
+    await midnight_callback(None)
+
+    assert api.prices_today == [{"date": "tomorrow-price"}]
+    assert api.prices_tomorrow == []
+    assert api.tomorrow_available is False
+    assert mock_hass.config_entries.async_forward_entry_setups.await_count == 1
+    assert dispatches


### PR DESCRIPTION
## Description
This PR adds the first focused pytest coverage for the integration's price-period and rollover logic.

The new tests cover shared price attribute generation, API day bucketing for today/tomorrow/forecast datasets, and the midnight rollover path that moves tomorrow prices into today. Together they give us regression coverage for the recent `prices` boundary fix and for the day-shift behavior around it.

## Test strategy
Ran `pytest -q`.

Ran `ruff format tests`.

Ran `ruff check tests`.

## Configuration changes
None.

## Proposed semver label
`patch` (not set in GitHub yet; awaiting maintainer verification before any label change)
