### PR TITLE
Making average price for cheapest hourse available to custom templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,28 @@ Add "Stromligning" integration _(If it doesn't show, try CTRL+F5 to force a refr
 
 ## Use the custom template to show the next x cheapest hours
 
-Copy the `custom_templates/FindCheapestPrice.jinja` to the `custom_templates` directory in your config folder (if it doesn't exist then create the folder)
-Reload Home Assistant and use the Jinja template by inserting the example below in a template sensor helper
+Copy the `custom_templates/FindCheapestPeriod.jinja` and `custom_templates/FindCheapestPeriodPrice.jinja` to the `custom_templates` directory in your config folder (if it doesn't exist then create the folder)
+Reload Home Assistant and use the Jinja template by inserting the example below in your configuration.yaml. If you already have defined a template section, just copy in the sensor.
 
 ```
-{% from 'FindCheapestPeriod.jinja' import FindCheapestPeriod%}
-{% set earliestStartTime = now() %}
-{% set latestStartTime = now() + timedelta(days=2) %}
-{% set periodLength = timedelta(hours=3) %}
-{{ FindCheapestPeriod(earliestStartTime , latestStartTime , periodLength, false) }}
+template:
+- sensor:
+      - name: "Buy Cheapest 3hr"
+        unique_id: buy_cheapest_3hr
+        device_class: timestamp
+        state: >
+          {% from 'FindCheapestPeriod.jinja' import FindCheapestPeriod%}
+          {% set earliestStartTime = now() %}
+          {% set latestStartTime = now() + timedelta(days=1) %}
+          {% set periodLength = timedelta(hours=3) %}
+          {{ FindCheapestPeriod(earliestStartTime , latestStartTime , periodLength, false) }}
+        attributes:
+          avg_price: >
+            {% from 'FindCheapestPeriodPrice.jinja' import FindCheapestPeriod%}
+            {% set earliestStartTime = now() %}
+            {% set latestStartTime = now() + timedelta(days=1) %}
+            {% set periodLength = timedelta(hours=3) %}
+            {{ FindCheapestPeriod(earliestStartTime , latestStartTime , periodLength, false) }}
 ```
 
-This will result in a sensor showing the cheapest 3 hours within the known prices
+This will result in a sensor showing the cheapest 3 hours within the known prices and the average price for these 3 hours as an attribute.

--- a/custom_templates/FindCheapestPeriodPrice.jinja
+++ b/custom_templates/FindCheapestPeriodPrice.jinja
@@ -1,0 +1,38 @@
+{%- macro FindCheapestPeriod(earliestDatetime, latestDatetime, durationTimedelta, findLastPeriodBoolean) -%}
+
+{# Prepare input parameters #}
+{%- set earliestDatetime = now() if earliestDatetime is not defined or earliestDatetime is not datetime else earliestDatetime -%}
+{%- set latestDatetime = now()+timedelta(days=7) if latestDatetime is not defined or latestDatetime is not datetime else latestDatetime -%}
+{%- set durationTimedelta = timedelta(hours=1) if durationTimedelta is not defined or durationTimedelta < timedelta(hours=1) else durationTimedelta -%}
+{%- set durationMinutes = durationTimedelta.total_seconds() // 60 | int -%}
+{%- set durationHours = "%.0f"|format((durationMinutes+30) // 60 | round | float) | int -%}
+
+{# Retrieve energy prices #}
+{%- set energyPriceToday = "sensor.stromligning_current_price_vat" -%}
+{%- set energyPriceTomorrow = "binary_sensor.stromligning_tomorrow_available_vat" -%}
+{%- set today = state_attr(energyPriceToday, 'prices') -%}
+{%- set tomorrow = state_attr(energyPriceTomorrow, 'prices') -%}
+{%- set prices = (today if today else []) + (tomorrow if tomorrow else []) -%}
+
+{# Calculate cheapest period #}
+{%- set result = namespace(priceSum=999999, priceStartTime=None) -%}
+{%- set prices_len = (prices | length) - durationHours | int -%}
+{%- for n in range(prices_len) -%}
+  {%- set priceStartTime = prices[n].start -%}
+  {%- if earliestDatetime <= priceStartTime and priceStartTime <= latestDatetime -%}
+    {%- set priceSum = namespace(value=0) -%}
+    {%- for i in range(durationHours) -%}
+      {%- set priceSum.value = priceSum.value + prices[n+i].price -%}
+    {%- endfor -%}
+    {%- if priceSum.value < result.priceSum or (findLastPeriodBoolean and priceSum.value <= result.priceSum) -%}
+      {%- set result.priceSum = priceSum.value -%}
+      {%- set result.priceAvg = priceSum.value / durationHours -%}
+      {%- set result.priceStartTime = priceStartTime -%}
+    {%- endif -%}
+  {%- endif -%}
+{%- endfor -%}
+
+{# Output result #}
+{{- result.priceAvg -}}
+
+{%- endmacro -%}


### PR DESCRIPTION
This PR is adding a new custom template file, allowing for the average price to be exposed. This will address the feature request raised in #274.

Additionally the readme file is updated to reflect this change.

This has been tested in local instance of HA.