### PR TITLE
Expose tomorrow prices as discrete array sensors

### DIFF
--- a/custom_components/stromligning/api.py
+++ b/custom_components/stromligning/api.py
@@ -307,6 +307,24 @@ class StromligningAPI:
         except ValueError:
             return None
 
+    def get_tomorrow_current(self, vat: bool = True) -> str | None:
+        """Get the first available price for tomorrow."""
+        if not self.prices_tomorrow:
+            return None
+        price = self.prices_tomorrow[0]
+        return price["price"]["total"] if vat else price["price"]["value"]
+
+    def get_tomorrow_spot(self, vat: bool = True) -> str | None:
+        """Get the first available spot price for tomorrow."""
+        if not self.prices_tomorrow:
+            return None
+        price = self.prices_tomorrow[0]
+        return (
+            price["details"]["electricity"]["total"]
+            if vat
+            else price["details"]["electricity"]["value"]
+        )
+
     def get_next_update(self) -> datetime:
         """Get next API update timestamp."""
         n_update = self.next_update.split(":")
@@ -334,7 +352,7 @@ class StromligningAPI:
     def get_power_provider(self) -> str:
         """Get power provider."""
         return self._data.company["name"]
-    
+
     def get_aggregation(self) -> str:
         """Get configured price aggregation."""
         return str(self._entry.options.get(CONF_AGGREGATION, "1h"))

--- a/custom_components/stromligning/sensor.py
+++ b/custom_components/stromligning/sensor.py
@@ -261,6 +261,54 @@ SENSORS = [
         unit_of_measurement="kr/kWh",  # type: ignore
     ),
     StromligningSensorEntityDescription(
+        key="tomorrow_price_vat",
+        entity_category=None,
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        icon="mdi:flash",
+        value_fn=lambda stromligning: stromligning.get_tomorrow_current(True),
+        suggested_display_precision=2,
+        entity_registry_enabled_default=True,
+        translation_key="tomorrow_price_vat",
+        unit_of_measurement="kr/kWh",  # type: ignore
+    ),
+    StromligningSensorEntityDescription(
+        key="tomorrow_price_ex_vat",
+        entity_category=None,
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        icon="mdi:flash",
+        value_fn=lambda stromligning: stromligning.get_tomorrow_current(False),
+        suggested_display_precision=2,
+        entity_registry_enabled_default=False,
+        translation_key="tomorrow_price_ex_vat",
+        unit_of_measurement="kr/kWh",  # type: ignore
+    ),
+    StromligningSensorEntityDescription(
+        key="tomorrow_spotprice_vat",
+        entity_category=None,
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        icon="mdi:transmission-tower-import",
+        value_fn=lambda stromligning: stromligning.get_tomorrow_spot(True),
+        suggested_display_precision=2,
+        entity_registry_enabled_default=True,
+        translation_key="tomorrow_spotprice_vat",
+        unit_of_measurement="kr/kWh",  # type: ignore
+    ),
+    StromligningSensorEntityDescription(
+        key="tomorrow_spotprice_ex_vat",
+        entity_category=None,
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        icon="mdi:transmission-tower-import",
+        value_fn=lambda stromligning: stromligning.get_tomorrow_spot(False),
+        suggested_display_precision=2,
+        entity_registry_enabled_default=False,
+        translation_key="tomorrow_spotprice_ex_vat",
+        unit_of_measurement="kr/kWh",  # type: ignore
+    ),
+    StromligningSensorEntityDescription(
         key="next_data_refresh",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=None,
@@ -530,6 +578,22 @@ class StromligningSensor(SensorEntity):
             ),
             "spotprice_ex_vat": (
                 self.api.prices_today,
+                lambda price: price["details"]["electricity"]["value"],
+            ),
+            "tomorrow_price_vat": (
+                self.api.prices_tomorrow,
+                lambda price: price["price"]["total"],
+            ),
+            "tomorrow_price_ex_vat": (
+                self.api.prices_tomorrow,
+                lambda price: price["price"]["value"],
+            ),
+            "tomorrow_spotprice_vat": (
+                self.api.prices_tomorrow,
+                lambda price: price["details"]["electricity"]["total"],
+            ),
+            "tomorrow_spotprice_ex_vat": (
+                self.api.prices_tomorrow,
                 lambda price: price["details"]["electricity"]["value"],
             ),
         }

--- a/custom_components/stromligning/translations/da.json
+++ b/custom_components/stromligning/translations/da.json
@@ -221,6 +221,38 @@
                 "state": {
                     "unknown": "Ukendt"
                 }
+            },
+            "tomorrow_price_vat": {
+                "name": "I morgen inkl. moms",
+                "state_attributes": {
+                    "prices": {
+                        "name": "Priser for i morgen"
+                    }
+                }
+            },
+            "tomorrow_price_ex_vat": {
+                "name": "I morgen ekskl. moms",
+                "state_attributes": {
+                    "prices": {
+                        "name": "Priser for i morgen"
+                    }
+                }
+            },
+            "tomorrow_spotprice_vat": {
+                "name": "Spotpris i morgen inkl. moms",
+                "state_attributes": {
+                    "prices": {
+                        "name": "Spotpriser for i morgen"
+                    }
+                }
+            },
+            "tomorrow_spotprice_ex_vat": {
+                "name": "Spotpris i morgen ekskl. moms",
+                "state_attributes": {
+                    "prices": {
+                        "name": "Spotpriser for i morgen"
+                    }
+                }
             }
         },
         "binary_sensor": {

--- a/custom_components/stromligning/translations/en.json
+++ b/custom_components/stromligning/translations/en.json
@@ -221,6 +221,38 @@
                 "state": {
                     "unknown": "Unknown"
                 }
+            },
+            "tomorrow_price_vat": {
+                "name": "Tomorrow incl. VAT",
+                "state_attributes": {
+                    "prices": {
+                        "name": "Prices tomorrow"
+                    }
+                }
+            },
+            "tomorrow_price_ex_vat": {
+                "name": "Tomorrow excl. VAT",
+                "state_attributes": {
+                    "prices": {
+                        "name": "Prices tomorrow"
+                    }
+                }
+            },
+            "tomorrow_spotprice_vat": {
+                "name": "Tomorrow spotprice incl. VAT",
+                "state_attributes": {
+                    "prices": {
+                        "name": "Spotprices tomorrow"
+                    }
+                }
+            },
+            "tomorrow_spotprice_ex_vat": {
+                "name": "Tomorrow spotprice excl. VAT",
+                "state_attributes": {
+                    "prices": {
+                        "name": "Spotprices tomorrow"
+                    }
+                }
             }
         },
         "binary_sensor": {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,187 @@
+"""Tests for tomorrow price sensors."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.stromligning.api import StromligningAPI
+
+
+def _build_api(mock_hass, mock_entry, prices: list[dict]) -> StromligningAPI:
+    """Create a partially initialized API object for focused unit tests."""
+    api = StromligningAPI.__new__(StromligningAPI)
+    api.hass = mock_hass
+    api._entry = mock_entry
+    api._data = SimpleNamespace(prices=prices)
+    api.prices_today = []
+    api.prices_tomorrow = []
+    api.prices_forecasts = []
+    api.forecast_data = False
+    api.tomorrow_available = False
+    api.listeners = []
+    api.last_update = None
+    return api
+
+
+class TestGetTomorrowCurrent:
+    """Tests for get_tomorrow_current API method."""
+
+    def test_returns_none_when_empty(self, mock_hass, mock_entry) -> None:
+        """Should return None when prices_tomorrow is empty."""
+        api = _build_api(mock_hass, mock_entry, [])
+        assert api.get_tomorrow_current(vat=True) is None
+        assert api.get_tomorrow_current(vat=False) is None
+
+    def test_returns_first_price_vat(self, mock_hass, mock_entry) -> None:
+        """Should return the first price total when vat=True."""
+        prices = [
+            {
+                "date": "2026-02-25T00:00:00+00:00",
+                "price": {"total": 1.50, "value": 1.20},
+            },
+            {
+                "date": "2026-02-25T01:00:00+00:00",
+                "price": {"total": 1.60, "value": 1.28},
+            },
+        ]
+        api = _build_api(mock_hass, mock_entry, [])
+        api.prices_tomorrow = prices
+        assert api.get_tomorrow_current(vat=True) == 1.50
+
+    def test_returns_first_price_ex_vat(self, mock_hass, mock_entry) -> None:
+        """Should return the first price value when vat=False."""
+        prices = [
+            {
+                "date": "2026-02-25T00:00:00+00:00",
+                "price": {"total": 1.50, "value": 1.20},
+            },
+        ]
+        api = _build_api(mock_hass, mock_entry, [])
+        api.prices_tomorrow = prices
+        assert api.get_tomorrow_current(vat=False) == 1.20
+
+
+class TestGetTomorrowSpot:
+    """Tests for get_tomorrow_spot API method."""
+
+    def test_returns_none_when_empty(self, mock_hass, mock_entry) -> None:
+        """Should return None when prices_tomorrow is empty."""
+        api = _build_api(mock_hass, mock_entry, [])
+        assert api.get_tomorrow_spot(vat=True) is None
+        assert api.get_tomorrow_spot(vat=False) is None
+
+    def test_returns_first_spot_vat(self, mock_hass, mock_entry) -> None:
+        """Should return the first spot price total when vat=True."""
+        prices = [
+            {
+                "date": "2026-02-25T00:00:00+00:00",
+                "price": {"total": 1.50, "value": 1.20},
+                "details": {
+                    "electricity": {"total": 0.80, "value": 0.64},
+                },
+            },
+        ]
+        api = _build_api(mock_hass, mock_entry, [])
+        api.prices_tomorrow = prices
+        assert api.get_tomorrow_spot(vat=True) == 0.80
+
+    def test_returns_first_spot_ex_vat(self, mock_hass, mock_entry) -> None:
+        """Should return the first spot price value when vat=False."""
+        prices = [
+            {
+                "date": "2026-02-25T00:00:00+00:00",
+                "price": {"total": 1.50, "value": 1.20},
+                "details": {
+                    "electricity": {"total": 0.80, "value": 0.64},
+                },
+            },
+        ]
+        api = _build_api(mock_hass, mock_entry, [])
+        api.prices_tomorrow = prices
+        assert api.get_tomorrow_spot(vat=False) == 0.64
+
+
+@pytest.mark.asyncio
+async def test_prepare_data_populates_tomorrow_with_confirmed_prices(
+    monkeypatch, mock_hass, mock_entry
+) -> None:
+    """Tomorrow prices should be populated when confirmed (non-forecast)."""
+    fixed_now = datetime(2026, 2, 24, 14, 0, tzinfo=UTC)
+    monkeypatch.setattr(
+        "custom_components.stromligning.api.dt_utils.now",
+        lambda: fixed_now,
+    )
+    monkeypatch.setattr(
+        "custom_components.stromligning.api.dt_utils.as_local",
+        lambda value: value,
+    )
+    monkeypatch.setattr(
+        "custom_components.stromligning.api.async_dispatcher_send",
+        lambda hass, signal: None,
+    )
+
+    prices = [
+        {
+            "date": f"2026-02-25T{hour:02d}:00:00+00:00",
+            "price": {"total": 1.0 + hour, "value": 0.8 + hour * 0.1},
+            "details": {
+                "electricity": {"total": 0.5 + hour * 0.05, "value": 0.4 + hour * 0.04},
+            },
+        }
+        for hour in range(24)
+    ]
+    api = _build_api(mock_hass, mock_entry, prices)
+
+    await api.prepare_data()
+
+    assert len(api.prices_tomorrow) == 24
+    assert api.tomorrow_available is True
+    assert api.forecast_data is False
+    assert api.get_tomorrow_current(vat=True) == 1.0
+    assert api.get_tomorrow_current(vat=False) == 0.8
+    assert api.get_tomorrow_spot(vat=True) == 0.5
+    assert api.get_tomorrow_spot(vat=False) == 0.4
+
+
+@pytest.mark.asyncio
+async def test_prepare_data_keeps_tomorrow_forecast_prices(
+    monkeypatch, mock_hass, mock_entry
+) -> None:
+    """Tomorrow forecast prices should be kept but tomorrow_available stays False."""
+    fixed_now = datetime(2026, 2, 24, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr(
+        "custom_components.stromligning.api.dt_utils.now",
+        lambda: fixed_now,
+    )
+    monkeypatch.setattr(
+        "custom_components.stromligning.api.dt_utils.as_local",
+        lambda value: value,
+    )
+    monkeypatch.setattr(
+        "custom_components.stromligning.api.async_dispatcher_send",
+        lambda hass, signal: None,
+    )
+
+    prices = [
+        {
+            "date": f"2026-02-25T{hour:02d}:00:00+00:00",
+            "price": {"total": 1.0 + hour, "value": 0.8 + hour * 0.1},
+            "details": {
+                "electricity": {"total": 0.5 + hour * 0.05, "value": 0.4 + hour * 0.04},
+            },
+            "forecast": True,
+        }
+        for hour in range(24)
+    ]
+    api = _build_api(mock_hass, mock_entry, prices)
+
+    await api.prepare_data()
+
+    assert len(api.prices_tomorrow) == 24
+    assert api.tomorrow_available is False
+    assert api.forecast_data is True
+    assert api.get_tomorrow_current(vat=True) == 1.0
+    assert api.get_tomorrow_spot(vat=True) == 0.5


### PR DESCRIPTION
Add tomorrow_price_vat/ex_vat and tomorrow_spotprice_vat/ex_vat sensors that expose the prices attribute from prices_tomorrow, matching the existing pattern used by current_price and forecasts sensors.

Closes the gap where tomorrow's confirmed prices were no longer available, since they were neither in today nor in forecast prices.

I added this in order to be able to create a "Next 24 hours electricity prices" graph on my home dashboard.