### PR TITLE
Add spot prices to forecast intervals

### DIFF
--- a/custom_components/stromligning/base.py
+++ b/custom_components/stromligning/base.py
@@ -54,6 +54,7 @@ def build_price_attributes(
     prices: list[dict[str, Any]],
     value_getter: PriceValueGetter,
     aggregation: str,
+    extra_value_getters: dict[str, PriceValueGetter] | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     """Build price attributes with deterministic period boundaries."""
     if not prices:
@@ -67,12 +68,15 @@ def build_price_attributes(
             if index < len(prices) - 1
             else _get_final_period_end(prices, aggregation)
         )
-        price_set.append(
-            {
-                "price": value_getter(price),
-                "start": price["date"],
-                "end": end,
-            }
-        )
+        interval = {
+            "price": value_getter(price),
+            "start": price["date"],
+            "end": end,
+        }
+        if extra_value_getters:
+            interval.update(
+                {name: getter(price) for name, getter in extra_value_getters.items()}
+            )
+        price_set.append(interval)
 
     return {"prices": price_set}

--- a/custom_components/stromligning/sensor.py
+++ b/custom_components/stromligning/sensor.py
@@ -533,6 +533,14 @@ class StromligningSensor(SensorEntity):
                 lambda price: price["details"]["electricity"]["value"],
             ),
         }
+        extra_price_attribute_map = {
+            "forecasts_vat": {
+                "spotprice": lambda price: price["details"]["electricity"]["total"]
+            },
+            "forecasts_ex_vat": {
+                "spotprice": lambda price: price["details"]["electricity"]["value"]
+            },
+        }
 
         at_attribute_map: dict[str, AtValueGetter] = {
             "today_min_vat": lambda api: api.get_specific_today(
@@ -567,6 +575,7 @@ class StromligningSensor(SensorEntity):
                 prices,
                 value_getter,
                 self.api.get_aggregation(),
+                extra_price_attribute_map.get(key),
             )
         elif key in at_attribute_map:
             self._attr_extra_state_attributes = {"at": at_attribute_map[key](self.api)}

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -82,3 +82,32 @@ def test_build_price_attributes_uses_aggregation_fallback_for_single_value() -> 
             }
         ]
     }
+
+
+def test_build_price_attributes_includes_extra_interval_values() -> None:
+    """Extra value getters should add values to every price interval."""
+    prices = [
+        {
+            "date": datetime(2026, 2, 24, 23, 0, tzinfo=UTC),
+            "price": {"total": 1.3},
+            "details": {"electricity": {"total": 0.8}},
+        }
+    ]
+
+    result = build_price_attributes(
+        prices,
+        lambda price: price["price"]["total"],
+        "1h",
+        {"spotprice": lambda price: price["details"]["electricity"]["total"]},
+    )
+
+    assert result == {
+        "prices": [
+            {
+                "price": 1.3,
+                "start": datetime(2026, 2, 24, 23, 0, tzinfo=UTC),
+                "end": datetime(2026, 2, 25, 0, 0, tzinfo=UTC),
+                "spotprice": 0.8,
+            }
+        ]
+    }

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,52 @@
+"""Tests for Strømligning sensor entities."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.stromligning.sensor import SENSORS, StromligningSensor
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("sensor_key", "expected_spotprice"),
+    [
+        ("forecasts_vat", 0.8),
+        ("forecasts_ex_vat", 0.64),
+    ],
+)
+async def test_forecast_attributes_include_matching_spotprice(
+    sensor_key: str, expected_spotprice: float
+) -> None:
+    """Forecast intervals should expose the matching VAT spot price."""
+    sensor = StromligningSensor.__new__(StromligningSensor)
+    sensor.entity_description = next(
+        description for description in SENSORS if description.key == sensor_key
+    )
+    sensor.api = SimpleNamespace(
+        prices_forecasts=[
+            {
+                "date": datetime(2026, 2, 24, 23, 0, tzinfo=UTC),
+                "price": {"total": 1.3, "value": 1.04},
+                "details": {"electricity": {"total": 0.8, "value": 0.64}},
+            }
+        ],
+        prices_today=[],
+        get_aggregation=lambda: "1h",
+    )
+
+    await sensor.handle_attributes()
+
+    assert sensor.extra_state_attributes == {
+        "prices": [
+            {
+                "price": 1.3 if sensor_key == "forecasts_vat" else 1.04,
+                "spotprice": expected_spotprice,
+                "start": datetime(2026, 2, 24, 23, 0, tzinfo=UTC),
+                "end": datetime(2026, 2, 25, 0, 0, tzinfo=UTC),
+            }
+        ]
+    }


### PR DESCRIPTION
## Summary

Add the raw electricity spot price to every interval exposed by the existing price forecast sensors. The `forecasts_vat` sensor reports the VAT-inclusive spot price, while `forecasts_ex_vat` reports the VAT-exclusive value.

The shared interval builder now accepts optional extra values, leaving all other price sensor attributes unchanged.

Fixes #346

## Test strategy

- `ruff format custom_components/stromligning/base.py custom_components/stromligning/sensor.py tests/test_base.py`
- `ruff check custom_components/stromligning/base.py custom_components/stromligning/sensor.py tests/test_base.py`
- `pytest -q` (10 passed)

## Known limitations

Spot prices are added to the existing forecast sensor intervals rather than exposed as separate entities. Forecast availability and accuracy continue to depend on the upstream data.

## Configuration changes

None. Existing users with forecasts enabled receive a new `spotprice` field in each forecast interval.